### PR TITLE
index.js: use did-navigate-in-page to save lastURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function createMainWindow() {
     win.setMaximumSize(maxWindowInteger, maxWindowInteger);
   });
 
-  win.webContents.on('did-navigate', (e, url) => {
+  win.webContents.on('did-navigate-in-page', (e, url) => {
     config.set('lastURL', url);
   });
 


### PR DESCRIPTION
The last page wasn’t being saved. Until I noticed that if I left Whale open for a long time, eventually Trello would timeout and then the page would save. So I could get Whale to open the page I wanted, but always needed that workaround.

The documentation makes it clear why:

[`did-navigate`](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#event-did-navigate) (emphasis mine):

> This event is **not emitted** for in-page navigations, such as **clicking anchor links** or updating the `window.location.hash`. **Use `did-navigate-in-page` event for this purpose**.

Tried it locally, and it worked like a charm. `did-navigate-in-page` works as expected.

Closes #2.