### PR TITLE
Features: Reload app window, Toggle full screen, Toggle dev tools

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -119,6 +119,12 @@ const darwinTpl = [{
         focusedWindow.reload();
       }
     }
+  }, {
+    label: 'Toggle Developer Tools',
+    accelerator: 'Alt+Command+I',
+    click: (item, focusedWindow) => {
+      focusedWindow.toggleDevTools();
+    }
   }]
 }, {
   role: 'window',
@@ -186,6 +192,12 @@ const otherTpl = [{
       if (focusedWindow) {
         focusedWindow.reload();
       }
+    }
+  }, {
+    label: 'Toggle Developer Tools',
+    accelerator: 'Ctrl+Shift+I',
+    click: (item, focusedWindow) => {
+      focusedWindow.toggleDevTools();
     }
   }]
 }, {

--- a/menu.js
+++ b/menu.js
@@ -111,6 +111,14 @@ const darwinTpl = [{
         focusedWindow.send('window:fullscreen', {state: focusedWindow.isFullScreen()});
       }
     }
+  }, {
+    label: 'Reload',
+    accelerator: 'CmdOrCtrl+R',
+    click: (item, focusedWindow) => {
+      if (focusedWindow) {
+        focusedWindow.reload();
+      }
+    }
   }]
 }, {
   role: 'window',
@@ -169,6 +177,14 @@ const otherTpl = [{
       if (focusedWindow) {
         focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
         focusedWindow.send('window:fullscreen', {state: focusedWindow.isFullScreen()});
+      }
+    }
+  }, {
+    label: 'Reload',
+    accelerator: 'CmdOrCtrl+R',
+    click: (item, focusedWindow) => {
+      if (focusedWindow) {
+        focusedWindow.reload();
       }
     }
   }]

--- a/menu.js
+++ b/menu.js
@@ -103,20 +103,20 @@ const darwinTpl = [{
 }, {
   label: 'View',
   submenu: [{
+    label: 'Reload',
+    accelerator: 'CmdOrCtrl+R',
+    click: (item, focusedWindow) => {
+      if (focusedWindow) {
+        focusedWindow.reload();
+      }
+    }
+  }, {
     label: 'Toggle Full Screen',
     accelerator: 'Ctrl+Command+F',
     click: (item, focusedWindow) => {
       if (focusedWindow) {
         focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
         focusedWindow.send('window:fullscreen', {state: focusedWindow.isFullScreen()});
-      }
-    }
-  }, {
-    label: 'Reload',
-    accelerator: 'CmdOrCtrl+R',
-    click: (item, focusedWindow) => {
-      if (focusedWindow) {
-        focusedWindow.reload();
       }
     }
   }, {
@@ -177,20 +177,20 @@ const otherTpl = [{
 }, {
   label: 'View',
   submenu: [{
+    label: 'Reload',
+    accelerator: 'CmdOrCtrl+R',
+    click: (item, focusedWindow) => {
+      if (focusedWindow) {
+        focusedWindow.reload();
+      }
+    }
+  }, {
     label: 'Toggle Full Screen',
     accelerator: 'F11',
     click: (item, focusedWindow) => {
       if (focusedWindow) {
         focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
         focusedWindow.send('window:fullscreen', {state: focusedWindow.isFullScreen()});
-      }
-    }
-  }, {
-    label: 'Reload',
-    accelerator: 'CmdOrCtrl+R',
-    click: (item, focusedWindow) => {
-      if (focusedWindow) {
-        focusedWindow.reload();
       }
     }
   }, {

--- a/menu.js
+++ b/menu.js
@@ -101,6 +101,18 @@ const darwinTpl = [{
     role: 'selectall'
   }]
 }, {
+  label: 'View',
+  submenu: [{
+    label: 'Toggle Full Screen',
+    accelerator: 'Control+Command+F',
+    click: (item, focusedWindow) => {
+      if (focusedWindow) {
+        focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+        focusedWindow.send('window:fullscreen', {state: focusedWindow.isFullScreen()});
+      }
+    }
+  }]
+}, {
   role: 'window',
   submenu: [{
     role: 'minimize'
@@ -147,6 +159,18 @@ const otherTpl = [{
     type: 'separator'
   }, {
     role: 'selectall'
+  }]
+}, {
+  label: 'View',
+  submenu: [{
+    label: 'Toggle Full Screen',
+    accelerator: 'F11',
+    click: (item, focusedWindow) => {
+      if (focusedWindow) {
+        focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+        focusedWindow.send('window:fullscreen', {state: focusedWindow.isFullScreen()});
+      }
+    }
   }]
 }, {
   role: 'help',

--- a/menu.js
+++ b/menu.js
@@ -104,7 +104,7 @@ const darwinTpl = [{
   label: 'View',
   submenu: [{
     label: 'Toggle Full Screen',
-    accelerator: 'Control+Command+F',
+    accelerator: 'Ctrl+Command+F',
     click: (item, focusedWindow) => {
       if (focusedWindow) {
         focusedWindow.setFullScreen(!focusedWindow.isFullScreen());


### PR DESCRIPTION
Hi!
Absolutely in love with the app 💓 🎉 
I took the time to organize a few already existing features like **window reload** and **dev tools toggling** and also add a **fullscreen feature** that might be useful! 

At a glance:

- Reload focused app window  
  - **Windows/Linux** <kbd>Ctrl</kbd> + <kbd>R</kdb>
  - **MacOS**  <kbd>Cmd</kbd> + <kbd>R</kdb>

- Toggle the app in and out of the full screen mode
  -  **Windows/Linux** <kbd>F11</kbd>
  - **MacOS**  <kbd>Cmd</kbd> + <kbd>F</kdb>

- Toggle dev tools alongside of the app
  -  **Windows/Linux** <kbd>Alt</kbd> + <kbd>Ctrl</kbd> +  <kbd>I</kbd>
  - **MacOS**  <kbd>Alt</kbd> + <kbd>Cmd</kbd> +  <kbd>I</kbd>

🚀 Tested on Windows 10 Pro, Linux Ubuntu 16.04 & Mac OS Sierra!

📷 Here are a few shots running the windows build!

## Menu overview

![view-menu-demo](https://cloud.githubusercontent.com/assets/12670537/25356737/06f8f8a2-2944-11e7-87a4-f573d55b4241.png)

## Dev tools toggled

![dev-tool-demo](https://cloud.githubusercontent.com/assets/12670537/25355690/269868ea-2940-11e7-8e87-b8f7d914a781.png)

## Toggling in and out of the full screen mode

![full-screen-demo](https://cloud.githubusercontent.com/assets/12670537/25355691/26a3ae08-2940-11e7-9879-a1e340acb8da.gif)

