### PR TITLE
Added zoom options to menu

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -111,6 +111,16 @@ const darwinTpl = [{
       }
     }
   }, {
+		type: 'separator'
+  }, {
+		role: 'zoomin'
+  }, {
+		role: 'zoomout'
+  }, {
+		role: 'resetzoom'
+  }, {
+		type: 'separator'
+  }, {
     label: 'Toggle Full Screen',
     accelerator: 'Ctrl+Command+F',
     click: (item, focusedWindow) => {
@@ -184,6 +194,16 @@ const otherTpl = [{
         focusedWindow.reload();
       }
     }
+  }, {
+		type: 'separator'
+  }, {
+		role: 'zoomin'
+  }, {
+		role: 'zoomout'
+  }, {
+		role: 'resetzoom'
+  }, {
+		type: 'separator'
   }, {
     label: 'Toggle Full Screen',
     accelerator: 'F11',


### PR DESCRIPTION
I was mising zoom options (I'm often working on laptop and having trello at 80 % zoom is nicely readable and with higher information density). Therefore this commit :).