### PR TITLE
Zooming options support

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,40 @@
+'use strict';
+const electron = require('electron');
+const config = require('./config');
+
+const ipc = electron.ipcRenderer;
+const webFrame = electron.webFrame;
+
+ipc.on('zoom-in', () => {
+  // Get zoom factor and increase it
+  const currentZoomFactor = webFrame.getZoomFactor();
+  const zoomFactor = currentZoomFactor + 0.05;
+  // Upper bound check
+  if (zoomFactor < 1.3) {
+    webFrame.setZoomFactor(zoomFactor);
+    config.set('zoomFactor', zoomFactor);
+  }
+});
+
+ipc.on('zoom-out', () => {
+  // Get zoom factor and decrease it
+  const currentZoomFactor = webFrame.getZoomFactor();
+  const zoomFactor = currentZoomFactor - 0.05;
+  // Lower bound check
+  if (zoomFactor > 0.7) {
+    webFrame.setZoomFactor(zoomFactor);
+    config.set('zoomFactor', zoomFactor);
+  }
+});
+
+ipc.on('zoom-reset', () => {
+  // Reset zoom factor
+  webFrame.setZoomFactor(1.0);
+  config.set('zoomFactor', 1.0);
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Preserve zoom factor
+  const zoomFactor = config.get('zoomFactor');
+  webFrame.setZoomFactor(zoomFactor);
+});

--- a/menu.js
+++ b/menu.js
@@ -6,6 +6,14 @@ const electron = require('electron');
 const app = electron.app;
 const shell = electron.shell;
 const appName = app.getName();
+const BrowserWindow = electron.BrowserWindow;
+
+function activate(command) {
+  const appWindow = BrowserWindow.getAllWindows()[0];
+  // Extra measure in order to be shown
+  appWindow.show();
+  appWindow.webContents.send(command);
+}
 
 const helpSubmenu = [{
   label: `${appName} Website`,
@@ -97,6 +105,28 @@ const darwinTpl = [{
       }
     }
   }, {
+    type: 'separator'
+  }, {
+    label: 'Make Text Larger',
+    accelerator: 'CmdOrCtrl+Plus',
+    click() {
+      activate('zoom-in');
+    }
+  }, {
+    label: 'Make Text Smaller',
+    accelerator: 'CmdOrCtrl+-',
+    click() {
+      activate('zoom-out');
+    }
+  }, {
+    label: 'Reset Zoom Level',
+    accelerator: 'CmdOrCtrl+0',
+    click() {
+      activate('zoom-reset');
+    }
+  }, {
+    type: 'separator'
+  }, {
     label: 'Toggle Full Screen',
     accelerator: 'Ctrl+Command+F',
     click: (item, focusedWindow) => {
@@ -170,6 +200,28 @@ const otherTpl = [{
         focusedWindow.reload();
       }
     }
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Make Text Larger',
+    accelerator: 'CmdOrCtrl+Plus',
+    click() {
+      activate('zoom-in');
+    }
+  }, {
+    label: 'Make Text Smaller',
+    accelerator: 'CmdOrCtrl+-',
+    click() {
+      activate('zoom-out');
+    }
+  }, {
+    label: 'Reset Zoom Level',
+    accelerator: 'CmdOrCtrl+0',
+    click() {
+      activate('zoom-reset');
+    }
+  }, {
+    type: 'separator'
   }, {
     label: 'Toggle Full Screen',
     accelerator: 'F11',

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,14 @@ brew cask install whale
 
 [Download](https://github.com/1000ch/whale/releases) and extract `.zip`, and move `Whale` to some location.
 
+## Keyboard shortcuts
+
+Description                | Keys
+-------------------------- | --------------------------
+Reset Zoom Level           | <kbd>Cmd/Ctrl</kbd> <kbd>0</kbd>
+Make Text Smaller          | <kbd>Cmd/Ctrl</kbd> <kbd>-</kbd>
+Make Text Larger           | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>=</kbd>
+
 ## License
 
 [MIT](https://1000ch.mit-license.org) © [Shogo Sensui](https://github.com/1000ch)


### PR DESCRIPTION
Adds support for `zooming in/out` and `resetting` the `zoom factor`. The zooming factor is preserved on app relaunch. Includes keyboard shortcuts + minor `readme` update. 

- Reset Zoom Level <kbd>Cmd/Ctrl</kbd> <kbd>0</kbd>
- Make Text Smaller <kbd>Cmd/Ctrl</kbd> <kbd>-</kbd>
- Make Text Larger <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>=</kbd>

![test](https://user-images.githubusercontent.com/12670537/31131413-c6fe01ea-a862-11e7-8d59-1a34e8fd6c99.gif)
