### PR TITLE
Feature: Keyboard shortcuts

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,205 @@
+'use strict';
+const electron = require('electron');
+
+const ipc = electron.ipcRenderer;
+const boardsListSelector = '.boards-page-board-section-list';
+
+function defaultView() {
+  // Reset menu to default view
+  document.querySelector('.board-menu-header-back-button').click();
+  document.querySelector('.board-menu-header-back-button').click();
+  document.querySelector('.board-menu-header-back-button').click();
+}
+
+ipc.on('toggle-profile', () => {
+  // Toggle profile
+  document.querySelector('.member-avatar').click();
+  document.querySelector('.js-profile').click();
+});
+
+ipc.on('toggle-notifications', () => {
+  // Toggle notifications
+  document.querySelector('.header-notifications').click();
+});
+
+ipc.on('subscribed-cards', () => {
+  // Toggle subscribed cards
+  document.querySelector('.member-avatar').click();
+  document.querySelector('.js-cards').click();
+});
+
+ipc.on('search', () => {
+  // Toggle search box
+  document.querySelector('.header-search').firstChild.click();
+});
+
+ipc.on('settings', () => {
+  // Toggle info
+  document.querySelector('.member-avatar').click();
+  document.querySelector('.js-account').click();
+});
+
+ipc.on('return-home', () => {
+  // Return home
+  document.querySelector('.header-logo-default').click();
+});
+
+ipc.on('change-language', () => {
+  // Change language
+  document.querySelector('.member-avatar').click();
+  document.querySelector('.js-change-locale').click();
+});
+
+ipc.on('log-out', () => {
+  // Log out
+  document.querySelector('.member-avatar').click();
+  document.querySelector('.js-logout').click();
+});
+
+ipc.on('star-board', () => {
+  // Star board
+  document.querySelector('.board-header-btn-icon.icon-star').click();
+});
+
+ipc.on('copy-board', () => {
+  // Copy board
+  defaultView();
+  document.querySelector('.js-open-more').click();
+  document.querySelector('.js-copy-board').click();
+});
+
+ipc.on('create-board', () => {
+  // Create board
+  document.querySelector('.js-open-add-menu').click();
+  document.querySelector('.js-new-board').click();
+});
+
+ipc.on('rename-board', () => {
+  // Rename board
+  document.querySelector('.board-header-btn-name').click();
+});
+
+ipc.on('toggle-info', () => {
+  // Toggle info
+  document.querySelector('.js-open-header-info-menu').click();
+});
+
+ipc.on('board-labels', () => {
+  // Subscribe to board
+  defaultView();
+  document.querySelector('.js-open-more').click();
+  document.querySelector('.js-open-labels').click();
+});
+
+ipc.on('board-archive', () => {
+  // Toggle board archived items
+  defaultView();
+  document.querySelector('.js-open-more').click();
+  document.querySelector('.js-open-archive').click();
+});
+
+ipc.on('toggle-stickers', () => {
+  // Toggle stickers
+  defaultView();
+  document.querySelector('.js-open-stickers').click();
+});
+
+ipc.on('board-subsribe', () => {
+  // Subscribe to board
+  defaultView();
+  document.querySelector('.js-open-more').click();
+  document.querySelector('.js-subscribed-state').click();
+});
+
+ipc.on('toggle-power-ups', () => {
+  // Toggle power-ups
+  defaultView();
+  document.querySelector('.js-open-power-ups').click();
+});
+
+ipc.on('create-team', () => {
+  // Create team
+  document.querySelector('.js-open-add-menu').click();
+  document.querySelector('.js-new-org').click();
+});
+
+ipc.on('add-members', () => {
+  // Add members to board
+  document.querySelector('.js-open-manage-board-members').click();
+});
+
+ipc.on('board-settings', () => {
+  // Toggle board settings
+  defaultView();
+  document.querySelector('.js-open-more').click();
+  document.querySelector('.js-open-settings').click();
+});
+
+ipc.on('print-export-board', () => {
+  // Print and export
+  defaultView();
+  document.querySelector('.js-open-more').click();
+  document.querySelector('.js-share').click();
+});
+
+ipc.on('change-background', () => {
+  // Change board background
+  document.querySelector('.board-menu-header-back-button').click();
+  document.querySelector('.js-change-background').click();
+});
+
+ipc.on('email-to-board-settings', () => {
+  // Toggle email-to-board settings
+  defaultView();
+  document.querySelector('.js-open-more').click();
+  document.querySelector('.js-email').click();
+});
+
+ipc.on('leave-board', () => {
+  // Leave board
+  defaultView();
+  document.querySelector('.js-open-more').click();
+  document.querySelector('.js-leave-board').click();
+});
+
+ipc.on('close-board', () => {
+  // Close board
+  defaultView();
+  document.querySelector('.js-open-more').click();
+  document.querySelector('.js-close-board').click();
+});
+
+function selectBoard(index) {
+  // Select the appropriate board based on given index
+  document.querySelector(boardsListSelector).children[index].firstChild.click();
+}
+
+function jumpToBoard(key) {
+  // Decrement given num since list indexing start add 0
+  const index = key - 1;
+  selectBoard(index);
+}
+
+document.addEventListener('keydown', event => {
+  let comboKey;
+
+  // OS check
+  if (process.platform === 'darwin') {
+    comboKey = event.metaKey;
+  } else {
+    comboKey = event.ctrlKey;
+  }
+
+  // Validity check
+  if (comboKey === false) {
+    return null;
+  }
+
+  // Parse as decimal
+  const givenNum = parseInt(event.key, 10);
+
+  // Get index
+  if (givenNum < 10 && givenNum > 0) {
+    jumpToBoard(givenNum);
+  }
+});

--- a/menu.js
+++ b/menu.js
@@ -129,6 +129,10 @@ const darwinTpl = [{
     click() {
       activate('log-out');
     }
+  }, {
+    type: 'separator'
+  }, {
+    role: 'quit'
   }]
 }, {
   label: 'Edit',
@@ -371,6 +375,10 @@ const otherTpl = [{
     click() {
       activate('log-out');
     }
+  }, {
+    type: 'separator'
+  }, {
+    role: 'quit'
   }]
 }, {
   label: 'Edit',

--- a/menu.js
+++ b/menu.js
@@ -6,6 +6,7 @@ const electron = require('electron');
 const app = electron.app;
 const shell = electron.shell;
 const appName = app.getName();
+const BrowserWindow = electron.BrowserWindow;
 
 const helpSubmenu = [{
   label: `${appName} Website`,
@@ -25,6 +26,13 @@ ${process.platform} ${process.arch} ${os.release()}`;
     shell.openExternal(`https://github.com/1000ch/whale/issues/new?body=${encodeURIComponent(body)}`);
   }
 }];
+
+function activate(command) {
+  const appWindow = BrowserWindow.getAllWindows()[0];
+  // Extra measure in order to be shown
+  appWindow.show();
+  appWindow.webContents.send(command);
+}
 
 if (process.platform !== 'darwin') {
   helpSubmenu.push({
@@ -66,6 +74,63 @@ const darwinTpl = [{
     role: 'quit'
   }]
 }, {
+  label: 'File',
+  submenu: [{
+    label: 'Profile',
+    accelerator: 'CmdorCtrl+P',
+    click() {
+      activate('toggle-profile');
+    }
+  }, {
+    label: 'Notifications',
+    accelerator: 'CmdorCtrl+N',
+    click() {
+      activate('toggle-notifications');
+    }
+  }, {
+    label: 'Subscribed Cards',
+    accelerator: 'CmdorCtrl+Shift+S',
+    click() {
+      activate('toggle-cards');
+    }
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Search',
+    accelerator: 'CmdorCtrl+F',
+    click() {
+      activate('search');
+    }
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Settings',
+    accelerator: 'CmdorCtrl+,',
+    click() {
+      activate('settings');
+    }
+  }, {
+    label: 'Return Home',
+    accelerator: 'CmdorCtrl+H',
+    click() {
+      activate('return-home');
+    }
+  }, {
+    label: 'Change language',
+    accelerator: 'CmdorCtrl+Shift+L',
+    click() {
+      activate('change-language');
+    }
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Log Out',
+    accelerator: 'CmdorCtrl+Shift+Q',
+    click() {
+      activate('log-out');
+    }
+  }]
+}, {
   label: 'Edit',
   submenu: [{
     role: 'undo'
@@ -85,6 +150,124 @@ const darwinTpl = [{
     role: 'delete'
   }, {
     role: 'selectall'
+  }]
+}, {
+  label: 'Boards',
+  submenu: [{
+    label: 'Board Actions',
+    submenu: [{
+      label: 'Star Board',
+      accelerator: 'CmdorCtrl+S',
+      click() {
+        activate('star-board');
+      }
+    }, {
+      label: 'Copy Board',
+      accelerator: 'CmdorCtrl+Shift+C',
+      click() {
+        activate('copy-board');
+      }
+    }, {
+      label: 'Create Board',
+      accelerator: 'CmdorCtrl+B',
+      click() {
+        activate('create-board');
+      }
+    }, {
+      label: 'Rename Board',
+      accelerator: 'CmdorCtrl+E',
+      click() {
+        activate('rename-board');
+      }
+    }, {
+      type: 'separator'
+    }, {
+      label: 'Info',
+      accelerator: 'CmdorCtrl+I',
+      click() {
+        activate('toggle-info');
+      }
+    }, {
+      label: 'Labels',
+      accelerator: 'CmdorCtrl+L',
+      click() {
+        activate('board-labels');
+      }
+    }, {
+      label: 'Archive',
+      accelerator: 'CmdorCtrl+Shift+E',
+      click() {
+        activate('board-archive');
+      }
+    }, {
+      label: 'Subscribe',
+      accelerator: 'CmdorCtrl+U',
+      click() {
+        activate('board-subsribe');
+      }
+    }, {
+      type: 'separator'
+    }, {
+      label: 'Stickers',
+      accelerator: 'CmdorCtrl+K',
+      click() {
+        activate('toggle-stickers');
+      }
+    }, {
+      label: 'Power-Ups',
+      accelerator: 'CmdorCtrl+O',
+      click() {
+        activate('toggle-power-ups');
+      }
+    }]
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Create Team',
+    accelerator: 'CmdorCtrl+T',
+    click() {
+      activate('create-team');
+    }
+  }, {
+    label: 'Add Members',
+    accelerator: 'CmdorCtrl+Shift+M',
+    click() {
+      activate('add-members');
+    }
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Board Settings',
+    accelerator: 'CmdorCtrl+Shift+,',
+    click() {
+      activate('board-settings');
+    }
+  }, {
+    label: 'Print/Export Board',
+    accelerator: 'CmdorCtrl+Shift+P',
+    click() {
+      activate('print-export-board');
+    }
+  }, {
+    label: 'Change Background',
+    accelerator: 'CmdorCtrl+Shift+B',
+    click() {
+      activate('change-background');
+    }
+  }, {
+    label: 'Email-to-Board Settings',
+    accelerator: 'CmdorCtrl+Shift+G',
+    click() {
+      activate('email-to-board-settings');
+    }
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Close Board',
+    accelerator: 'CmdorCtrl+Shift+Y',
+    click() {
+      activate('close-board');
+    }
   }]
 }, {
   label: 'View',
@@ -135,7 +318,59 @@ const darwinTpl = [{
 const otherTpl = [{
   label: 'File',
   submenu: [{
-    role: 'quit'
+    label: 'Profile',
+    accelerator: 'CmdorCtrl+P',
+    click() {
+      activate('toggle-profile');
+    }
+  }, {
+    label: 'Notifications',
+    accelerator: 'CmdorCtrl+N',
+    click() {
+      activate('toggle-notifications');
+    }
+  }, {
+    label: 'Subscribed Cards',
+    accelerator: 'CmdorCtrl+Shift+S',
+    click() {
+      activate('subscribed-cards');
+    }
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Search',
+    accelerator: 'CmdorCtrl+F',
+    click() {
+      activate('search');
+    }
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Settings',
+    accelerator: 'CmdorCtrl+,',
+    click() {
+      activate('settings');
+    }
+  }, {
+    label: 'Return Home',
+    accelerator: 'CmdorCtrl+H',
+    click() {
+      activate('return-home');
+    }
+  }, {
+    label: 'Change language',
+    accelerator: 'CmdorCtrl+Shift+L',
+    click() {
+      activate('change-language');
+    }
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Log Out',
+    accelerator: 'CmdorCtrl+Shift+Q',
+    click() {
+      activate('log-out');
+    }
   }]
 }, {
   label: 'Edit',
@@ -159,6 +394,124 @@ const otherTpl = [{
     type: 'separator'
   }, {
     role: 'selectall'
+  }]
+}, {
+  label: 'Boards',
+  submenu: [{
+    label: 'Board Actions',
+    submenu: [{
+      label: 'Star Board',
+      accelerator: 'CmdorCtrl+S',
+      click() {
+        activate('star-board');
+      }
+    }, {
+      label: 'Copy Board',
+      accelerator: 'CmdorCtrl+Shift+C',
+      click() {
+        activate('copy-board');
+      }
+    }, {
+      label: 'Create Board',
+      accelerator: 'CmdorCtrl+B',
+      click() {
+        activate('create-board');
+      }
+    }, {
+      label: 'Rename Board',
+      accelerator: 'CmdorCtrl+E',
+      click() {
+        activate('rename-board');
+      }
+    }, {
+      type: 'separator'
+    }, {
+      label: 'Info',
+      accelerator: 'CmdorCtrl+I',
+      click() {
+        activate('toggle-info');
+      }
+    }, {
+      label: 'Labels',
+      accelerator: 'CmdorCtrl+L',
+      click() {
+        activate('board-labels');
+      }
+    }, {
+      label: 'Archive',
+      accelerator: 'CmdorCtrl+Shift+E',
+      click() {
+        activate('board-archive');
+      }
+    }, {
+      label: 'Subscribe',
+      accelerator: 'CmdorCtrl+U',
+      click() {
+        activate('board-subsribe');
+      }
+    }, {
+      type: 'separator'
+    }, {
+      label: 'Stickers',
+      accelerator: 'CmdorCtrl+K',
+      click() {
+        activate('toggle-stickers');
+      }
+    }, {
+      label: 'Power-Ups',
+      accelerator: 'CmdorCtrl+O',
+      click() {
+        activate('toggle-power-ups');
+      }
+    }]
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Create Team',
+    accelerator: 'CmdorCtrl+T',
+    click() {
+      activate('create-team');
+    }
+  }, {
+    label: 'Add Members',
+    accelerator: 'CmdorCtrl+Shift+M',
+    click() {
+      activate('add-members');
+    }
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Board Settings',
+    accelerator: 'CmdorCtrl+Shift+,',
+    click() {
+      activate('board-settings');
+    }
+  }, {
+    label: 'Print/Export Board',
+    accelerator: 'CmdorCtrl+Shift+P',
+    click() {
+      activate('print-export-board');
+    }
+  }, {
+    label: 'Change Background',
+    accelerator: 'CmdorCtrl+Shift+B',
+    click() {
+      activate('change-background');
+    }
+  }, {
+    label: 'Email-to-Board Settings',
+    accelerator: 'CmdorCtrl+Shift+G',
+    click() {
+      activate('email-to-board-settings');
+    }
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Close Board',
+    accelerator: 'CmdorCtrl+Shift+Y',
+    click() {
+      activate('close-board');
+    }
   }]
 }, {
   label: 'View',

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,37 @@ brew cask install whale
 
 [Download](https://github.com/1000ch/whale/releases) and extract `.zip`, and move `Whale` to some location.
 
+## Keyboard shortcuts
+
+Description                | Keys
+-------------------------- | --------------------------
+Search                     | <kbd>Cmd/Ctrl</kbd> <kbd>F</kbd>
+Settings                   | <kbd>Cmd/Ctrl</kbd> <kbd>,</kbd>
+Star Board                 | <kbd>Cmd/Ctrl</kbd> <kbd>S</kbd>
+Toggle Info                | <kbd>Cmd/Ctrl</kbd> <kbd>I</kbd>
+Create Team                | <kbd>Cmd/Ctrl</kbd> <kbd>T</kbd>
+Return Home                | <kbd>Cmd/Ctrl</kbd> <kbd>H</kbd>
+Create Board               | <kbd>Cmd/Ctrl</kbd> <kbd>B</kbd>
+Rename Board               | <kbd>Cmd/Ctrl</kbd> <kbd>E</kbd>
+Toggle Labels              | <kbd>Cmd/Ctrl</kbd> <kbd>L</kbd>
+Toggle Profile             | <kbd>Cmd/Ctrl</kbd> <kbd>P</kbd>
+Toggle Stickers            | <kbd>Cmd/Ctrl</kbd> <kbd>K</kbd>
+Toggle Power-Ups           | <kbd>Cmd/Ctrl</kbd> <kbd>O</kbd>
+Subscribe to Board         | <kbd>Cmd/Ctrl</kbd> <kbd>U</kbd>
+Toggle Notifications       | <kbd>Cmd/Ctrl</kbd> <kbd>N</kbd>
+Jump to Board              | <kbd>Cmd/Ctrl</kbd> <kbd>1</kbd> - <kbd>9</kbd>
+Log Out                    | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>Q</kbd>
+Copy Board                 | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>C</kbd>
+Add Members                | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>M</kbd>
+Close Board                | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>Y</kbd>
+Toggle Archive             | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>E</kbd>
+Board Settings             | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>,</kbd>
+Change Language            | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>L</kbd>
+Change Background          | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>B</kbd>
+Print/Export Board         | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>P</kbd>
+Toggle Subscribed Cards    | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>S</kbd>
+Email-to-Board Settings    | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>G</kbd>
+
 ## License
 
 [MIT](https://1000ch.mit-license.org) © [Shogo Sensui](https://github.com/1000ch)


### PR DESCRIPTION
#19 follow-up. 
Adds 34 keyboard shortcut in total, including the ability, present also on the official app, to directly jump to any of the **nine first stared boards** using <kbd>Cmd/Ctrl</kbd> <kbd>1</kbd> - <kbd>9</kbd> while the user is on home view. 
There should be no collisions with the native shortcut keys.  Full list is [here](https://github.com/1000ch/whale/blob/e0f9107f5236842f3f415360776c5c7d0bcc5274/readme.md#keyboard-shortcuts).
@1000ch feel free to suggest edits : )