### PR TITLE
replace deprecated `brew cask` in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Unofficial [Trello](https://trello.com/) app
 Alternatively, if you use [Homebrew](http://brew.sh/), you can install via:
 
 ```
-brew cask install whale
+brew install --cask whale
 ```
 
 ### Windows


### PR DESCRIPTION
switch Mac install instructions to `brew install --cask whale` as per https://formulae.brew.sh/cask/whale